### PR TITLE
Ensure draggable placeholder has same column structure as dragged item.

### DIFF
--- a/simple-page-ordering.dev.js
+++ b/simple-page-ordering.dev.js
@@ -77,6 +77,7 @@ sortable_post_table.sortable({
 			inlineEditPost.revert();
 		}
 		ui.placeholder.height(ui.item.height());
+		ui.placeholder.html(ui.item.html()).find('> th, > td').html('');
 	},
 	helper: function(e, ui) {
 		var children = ui.children();


### PR DESCRIPTION
This plugin in the best one I've found for drag-n-drop WordPress page ordering within the core admin UI :+1: 

However, we found an issue where sometimes when dragging the a row, the table structured messed up. The placeholder element seemed to have more columns than the table and so the table ended up with lots of empty (non-existent) cells on the right which pushed everything out of alignment.

The worse thing out this was that if you were half way down a scrolled page, when you started dragging an item the page would jump so the dragged item was instantly in the wrong place so you could'nt just drop it in exactly the same place or drag it one or two places in the table easily.

This PR copies the column structure of the dragged item, empties all the cell content and uses that as the placeholder to ensure the table structure is preserved. This prevents the page jump for a much smoother experience.

I've done some testing and it seems to work well, so if you can confirm this is a good solution I'd love to see it fixed in the core plugin.

Many thanks for your efforts with this plugin.

Ben
