### PR TITLE
Fix Sort by Order link in some situations

### DIFF
--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -281,7 +281,7 @@ class Simple_Page_Ordering {
 	 */
 	public static function sort_by_order_link( $views ) {
 		$class = ( get_query_var('orderby') == 'menu_order title' ) ? 'current' : '';
-		$query_string = esc_url( remove_query_arg( array( 'orderby', 'order' ) ) );
+		$query_string = esc_url_raw( remove_query_arg( array( 'orderby', 'order' ) ) );
 		if ( ! is_post_type_hierarchical( get_post_type() ) ) {
 			$query_string = add_query_arg( 'orderby', 'menu_order title', $query_string );
 			$query_string = add_query_arg( 'order', 'asc', $query_string );


### PR DESCRIPTION
esc_url function is meant to be used when displaying URL's, not when actually using those addresses. This PR changes function to esc_url_raw which functions similar to esc_url() but does not replace entities for display.