### PR TITLE
Update readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: jakemgold, 10up, thinkoomph
 Donate link: http://10up.com/plugins/simple-page-ordering-wordpress/
 Tags: order, re-order, ordering, pages, page, manage, menu_order, hierarchical, ajax, drag-and-drop, admin
 Requires at least: 3.8
-Tested up to: 4.1
-Stable tag: 2.2.4
+Tested up to: 4.9.2
+Stable tag: 2.2.5
 
 Order your pages and other hierarchical post types with simple drag and drop right from the standard page list.
 
@@ -76,6 +76,9 @@ This feature is already built into WordPress natively, but a bit tucked away. If
 
 
 == Changelog ==
+
+= 2.2.5 =
+* Fixed Sort by Order link when sorting on taxonomy or user posts list
 
 = 2.2.4 =
 * Fixed redundant URL encoding when sorting in admin page list

--- a/simple-page-ordering.php
+++ b/simple-page-ordering.php
@@ -281,7 +281,7 @@ class Simple_Page_Ordering {
 	 */
 	public static function sort_by_order_link( $views ) {
 		$class = ( get_query_var('orderby') == 'menu_order title' ) ? 'current' : '';
-		$query_string = esc_url( remove_query_arg( array( 'orderby', 'order' ) ) );
+		$query_string = esc_url_raw( remove_query_arg( array( 'orderby', 'order' ) ) );
 		if ( ! is_post_type_hierarchical( get_post_type() ) ) {
 			$query_string = add_query_arg( 'orderby', 'menu_order title', $query_string );
 			$query_string = add_query_arg( 'order', 'asc', $query_string );


### PR DESCRIPTION
Bump tested up to WP version and plugin version in readme.txt so we can get rid off that "This plugin hasn’t been tested with the latest 3 major releases of WordPress." notice on w.org/plugins